### PR TITLE
Fix the dependencies for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ functional: build
 	@echo Executing with: $(BUILD_VARS) tox -e functional
 	@$(BUILD_VARS) tox -e functional
 
-build:
+build: submodules
 	@echo "Building charm to base directory $(JUJU_REPOSITORY)"
 	@-git describe --tags > ./repo-info
 	@LAYER_PATH=./layers INTERFACE_PATH=./interfaces TERM=linux \

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -5,5 +5,5 @@ pytest
 pytest-cov
 pytest-html
 signedjson
-psycopg2
+psycopg2-binary
 PyOpenSSL


### PR DESCRIPTION
Added submodules as a dependent target for the build in the Makefile

For testing updates / changed the psycopg2 to psycopg2-binary as
supported (and actually suggested), reducing the dependencies on
external packages to be installed.

this will fix issue #5 