### PR TITLE
Added support to start listening on port 8448

### DIFF
--- a/lib/lib_matrix.py
+++ b/lib/lib_matrix.py
@@ -268,15 +268,27 @@ class MatrixHelper:
         else:
             self.external_port = 80
 
+        internal_host = socket.getfqdn()
         proxy_config = [
             {
                 "mode": "http",
                 "external_port": self.external_port,
-                "internal_host": socket.getfqdn(),
+                "internal_host": internal_host,
                 "internal_port": 8008,
                 "subdomain": server_name,
-            }
+            },
         ]
+
+        if tls_enabled:
+            proxy_config.append(
+                {
+                    "mode": "http",
+                    "external_port": 8448,
+                    "internal_host": internal_host,
+                    "internal_port": 8008,
+                    "subdomain": server_name,
+                }
+            )
         proxy.configure(proxy_config)
 
     def pgsql_configured(self):


### PR DESCRIPTION
If tls is enabled the charm will instruct haproxy to start listening on
port 8448 as well, so that this facilitates federation on the default
ports.

This will fix issue #2.